### PR TITLE
Use Rust's #[non_exhaustive] lint for enums

### DIFF
--- a/src/colortype.rs
+++ b/src/colortype.rs
@@ -1,6 +1,5 @@
-use crate::NonExhaustiveMarker;
-
 /// An enumeration over supported color types and bit depths
+#[non_exhaustive]
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ColorType {
     /// Pixel is 8-bit luminance
@@ -25,9 +24,6 @@ pub enum ColorType {
     Bgr8,
     /// Pixel is 8-bit BGR with an alpha channel
     Bgra8,
-
-    #[doc(hidden)]
-    __Nonexhaustive(NonExhaustiveMarker),
 }
 
 impl ColorType {
@@ -66,6 +62,7 @@ impl ColorType {
 /// Another purpose is to advise users of a rough estimate of the accuracy and effort of the
 /// decoding from and encoding to such an image format.
 #[allow(missing_docs)]
+#[non_exhaustive]
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ExtendedColorType {
     L1,
@@ -95,9 +92,6 @@ pub enum ExtendedColorType {
     /// which are associated with an external palette. In that case, the pixel value is an index
     /// into the palette.
     Unknown(u8),
-
-    #[doc(hidden)]
-    __Nonexhaustive(NonExhaustiveMarker),
 }
 
 impl ExtendedColorType {

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,6 @@ use std::{fmt, io};
 
 use crate::ExtendedColorType;
 use crate::ImageFormat;
-use crate::NonExhaustiveMarker;
 
 /// The generic error type for image operations.
 ///
@@ -77,6 +76,7 @@ pub struct UnsupportedError {
 }
 
 /// Details what feature is not supported.
+#[non_exhaustive]
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub enum UnsupportedErrorKind {
     /// The required color type can not be handled.
@@ -86,8 +86,6 @@ pub enum UnsupportedErrorKind {
     /// Some feature specified by string.
     /// This is discouraged and is likely to get deprecated (but not removed).
     GenericFeature(String),
-    #[doc(hidden)]
-    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// An error was encountered while encoding an image.
@@ -115,6 +113,7 @@ pub struct ParameterError {
 }
 
 /// Details how a parameter is malformed.
+#[non_exhaustive]
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub enum ParameterErrorKind {
     /// The dimensions passed are wrong.
@@ -126,9 +125,6 @@ pub enum ParameterErrorKind {
     Generic(String),
     /// The end of the image has been reached.
     NoMoreData,
-    #[doc(hidden)]
-    /// Do not use this, not part of stability guarantees.
-    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// An error was encountered while decoding an image.
@@ -162,18 +158,17 @@ pub struct LimitError {
 /// detailed information or to incorporate other resources types.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 #[allow(missing_copy_implementations)] // Might be non-Copy in the future.
+#[non_exhaustive]
 pub enum LimitErrorKind {
     /// The resulting image exceed dimension limits in either direction.
     DimensionError,
     /// The operation would have performed an allocation larger than allowed.
     InsufficientMemory,
-    #[doc(hidden)]
-    /// Do not use this, not part of stability guarantees.
-    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// A best effort representation for image formats.
 #[derive(Clone, Debug, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum ImageFormatHint {
     /// The format is known exactly.
     Exact(ImageFormat),
@@ -186,9 +181,6 @@ pub enum ImageFormatHint {
 
     /// The format is not known or could not be determined.
     Unknown,
-
-    #[doc(hidden)]
-    __NonExhaustive(NonExhaustiveMarker),
 }
 
 impl UnsupportedError {

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,7 +1,6 @@
-use crate::NonExhaustiveMarker;
-
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.
+#[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum ImageFormat {
     /// An Image in PNG Format
@@ -36,7 +35,4 @@ pub enum ImageFormat {
 
     /// An Image in Radiance HDR Format
     Hdr,
-
-    #[doc(hidden)]
-    __NonExhaustive(NonExhaustiveMarker),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,21 +14,5 @@ pub use decoder::*;
 pub use error::*;
 pub use format::ImageFormat;
 
-/// A marker struct for __NonExhaustive enums.
-///
-/// This is an empty type that can not be constructed. When an enum contains a tuple variant that
-/// includes this type the optimizer can statically determined tha the branch is never taken while
-/// at the same time the matching of the branch is required.
-///
-/// The effect is thus very similar to the actual `#[non_exhaustive]` attribute with no runtime
-/// costs. Also note that we use a dirty trick to not only hide this type from the doc but make it
-/// inaccessible. The visibility in this module is pub but the module itself is not and the
-/// top-level crate never exports the type.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct NonExhaustiveMarker {
-    /// Allows this crate, and this crate only, to match on the impossibility of this variant.
-    pub(crate) _private: Empty,
-}
-
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Empty {}


### PR DESCRIPTION
Rust provides its own `#[non_exhaustive]` lint after [RFC 2008](https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md). Use compiler provided guarantee could make better docs, and a better way for pattern matching without breaking backward compability.

To make a proof of concept of usage, users may need to create another crate. Within one crate (a.k.a. the `image-core` itself) the `non_exhaustive` only behaves like normal enums. But in other crates if we need to use this enum (e.g. other crate use `image-core`'s enum), there should always be a reserved `_` arm on match blocks whenever all arms are already covered.

This change should be zero-cost with the original way. (If I am incorrect, please reply and inform me, thanks :)